### PR TITLE
Response is read, however now we get Bad Response

### DIFF
--- a/src/main/scala/com/github/sguzman/scala/remote/web/Main.scala
+++ b/src/main/scala/com/github/sguzman/scala/remote/web/Main.scala
@@ -1,11 +1,11 @@
 package com.github.sguzman.scala.remote.web
 
-import lol.http._
+import lol.http.{HttpString, _}
 import org.apache.commons.lang3.StringUtils
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
-import scalaj.http.{Http, HttpResponse}
+import scalaj.http.Http
 
 object Main {
   def main(args: Array[String]): Unit = {
@@ -35,7 +35,7 @@ object Main {
     }
   }
 
-  def request(e: Request): HttpResponse[String] = {
+  def request(e: Request): scalaj.http.HttpResponse[String] = {
     val remoteWebHeaders = e.headers
       .filter(_._1.str.startsWith("Remote-Web-"))
       .map(t => (StringUtils.substringAfter(t._1.str, "Remote-Web-"), t._2.str))
@@ -44,10 +44,11 @@ object Main {
     val scheme = e.headers.getOrElse(HttpString("Remote-Scheme"), "https")
     val method = e.method
 
-    val host = e.headers(HttpString("Remote-Web-Host"))
+    val host = e.headers.getOrElse(HttpString("Remote-Web-Host"),HttpString("localhost"))
     val path = e.url
+    val port = 8888
 
-    val uri = s"$scheme://$host$path"
+    val uri = s"$scheme://$host:$port$path"
     println(s"Received a request for $uri")
 
     val request = Http(uri)


### PR DESCRIPTION
The response is returned, but the current config now needs a ticket for both configuring the repo (say being able to run the same environment on a separate machine).
We also need to specify the expected behavior, the message is received but the server currently responds to the requester with a "Bad Response" message